### PR TITLE
Support safe handles

### DIFF
--- a/src/global_config.rs
+++ b/src/global_config.rs
@@ -1,0 +1,11 @@
+pub(crate) struct GlobalConfig {
+    pub use_safe_handles: bool,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        GlobalConfig {
+            use_safe_handles: false,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ impl Display for CSType {
                 write!(f, "ref {}", name)
             } else {
                 if self.use_safe_handle {
-                    write!(f, "Safe{}Handle", name)
+                    write!(f, "{}Handle", name)
                 } else {
                     write!(f, "IntPtr /* {} */", name)
                 }
@@ -507,7 +507,11 @@ impl Builder {
     /// by the Rust code, which C# doesn't know the structure of) should be
     /// assumed to be [`SafeHandle`][] subclasses instead of `IntPtr`s. This means that
     /// the actual definition of the `SafeHandle` subclass will need to be provided by
-    /// external code.
+    /// external code. The name of the `SafeHandle` subclass will be the name of the
+    /// Rust type pointed to with `Handle` appended to the end, e.g. `*mut Path2D`
+    /// will become `Path2DHandle` (as opposed to `IntPtr`).
+    /// 
+    /// [`SafeHandle`]: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.safehandle
     pub fn use_safe_handles(mut self) -> Self {
         self.gconf.use_safe_handles = true;
         self

--- a/tests/rust/safe_handles_example.rs
+++ b/tests/rust/safe_handles_example.rs
@@ -1,0 +1,3 @@
+pub type MyOpaqueRef = *mut MyOpaqueStruct;
+
+pub unsafe extern "C" fn blarg(c: MyOpaqueRef) -> u8 { 120 }

--- a/tests/snapshots/test_everything__safe_handles_example.snap
+++ b/tests/snapshots/test_everything__safe_handles_example.snap
@@ -1,0 +1,17 @@
+---
+created: "2019-07-14T11:38:44.025356Z"
+creator: insta@0.8.1
+source: tests/test_everything.rs
+expression: code
+---
+// This file has been auto-generated, please do not edit it.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal class RustExports {
+    [DllImport("MyDll")]
+    internal static extern byte blarg(SafeMyOpaqueStructHandle c);
+
+}
+

--- a/tests/snapshots/test_everything__safe_handles_example.snap
+++ b/tests/snapshots/test_everything__safe_handles_example.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-07-14T11:38:44.025356Z"
+created: "2019-07-14T11:57:45.370831700Z"
 creator: insta@0.8.1
 source: tests/test_everything.rs
-expression: code
+expression: builder.generate().unwrap()
 ---
 // This file has been auto-generated, please do not edit it.
 
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 internal class RustExports {
     [DllImport("MyDll")]
-    internal static extern byte blarg(SafeMyOpaqueStructHandle c);
+    internal static extern byte blarg(MyOpaqueStructHandle c);
 
 }
 

--- a/tests/test_everything.rs
+++ b/tests/test_everything.rs
@@ -28,3 +28,14 @@ fn test_main_example() {
 
     assert_snapshot_matches!(example_name, code);
 }
+
+#[test]
+fn test_safe_handles() {
+    let example_name = "safe_handles_example";
+    let code = Builder::new("MyDll", load_example(example_name))
+        .use_safe_handles()
+        .generate()
+        .unwrap();
+
+    assert_snapshot_matches!(example_name, code);
+}

--- a/tests/test_everything.rs
+++ b/tests/test_everything.rs
@@ -7,6 +7,11 @@ use csharpbindgen::{
     CSAccess
 };
 
+fn run_example_test<F: FnOnce(Builder) -> Builder>(name: &'static str, build: F) {
+    let builder = build(Builder::new("MyDll", load_example(name)));
+    assert_snapshot_matches!(name, builder.generate().unwrap());
+}
+
 fn load_example(name: &'static str) -> String {
     let mut path = PathBuf::new();
     path.push("tests");
@@ -17,25 +22,15 @@ fn load_example(name: &'static str) -> String {
 
 #[test]
 fn test_main_example() {
-    let example_name = "main_example";
-    let code = Builder::new("MyDll", load_example(example_name))
-        .class_name("MyStuff")
-        .ignore(&["ignore_*", "IGNORE_*", "Ignore*"])
-        .access("public_func", CSAccess::Public)
-        .access("PublicStruct", CSAccess::Public)
-        .generate()
-        .unwrap();
-
-    assert_snapshot_matches!(example_name, code);
+    run_example_test("main_example", |b|
+        b.class_name("MyStuff")
+         .ignore(&["ignore_*", "IGNORE_*", "Ignore*"])
+         .access("public_func", CSAccess::Public)
+         .access("PublicStruct", CSAccess::Public)
+    );
 }
 
 #[test]
 fn test_safe_handles() {
-    let example_name = "safe_handles_example";
-    let code = Builder::new("MyDll", load_example(example_name))
-        .use_safe_handles()
-        .generate()
-        .unwrap();
-
-    assert_snapshot_matches!(example_name, code);
+    run_example_test("safe_handles_example", |b| b.use_safe_handles());
 }


### PR DESCRIPTION
In https://github.com/toolness/pathfinder-unity-fun/issues/9 it was suggested that we use C#'s [`SafeHandle`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.safehandle?view=netframework-4.8) instead of `IntPtr`.  This adds a `Builder::use_safe_handles()` method which supports this use case.