### PR TITLE
Run rustfmt as part of CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,3 +28,6 @@ jobs:
       - run:
           name: Run all tests
           command: cargo test --all
+      - run:
+          name: Ensure code is consistently formatted via rustfmt
+          command: rustup component add rustfmt && cargo fmt --all -- --check

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::fmt::{Formatter, Display};
+use std::fmt::{Display, Formatter};
 
 /// This represents an error from the library.
 #[derive(Debug)]
@@ -11,7 +11,7 @@ pub enum Error {
     /// be converted to C#. The first item is the error message,
     /// and the second is the identifier in the source Rust
     /// code that caused the error.
-    UnsupportedError(String, Option<syn::Ident>)
+    UnsupportedError(String, Option<syn::Ident>),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
@@ -19,9 +19,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Error::SynError(err) => {
-                write!(f, "Couldn't parse Rust code: {}", err)
-            },
+            Error::SynError(err) => write!(f, "Couldn't parse Rust code: {}", err),
             Error::UnsupportedError(reason, maybe_ident) => {
                 let loc = if let Some(ident) = maybe_ident {
                     format!(" while processing symbol \"{}\"", ident.to_string())
@@ -37,12 +35,8 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::SynError(ref err) => {
-                Some(err)
-            },
-            Error::UnsupportedError(_, _) => {
-                None
-            }
+            Error::SynError(ref err) => Some(err),
+            Error::UnsupportedError(_, _) => None,
         }
     }
 }
@@ -51,7 +45,7 @@ pub(crate) fn add_ident<T>(result: Result<T>, ident: &syn::Ident) -> Result<T> {
     match result {
         Err(Error::UnsupportedError(reason, None)) => {
             Err(Error::UnsupportedError(reason, Some(ident.clone())))
-        },
-        _ => result
+        }
+        _ => result,
     }
 }

--- a/src/ignores.rs
+++ b/src/ignores.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 pub struct Ignores {
     exact: BTreeSet<String>,
-    prefixes: Vec<String>
+    prefixes: Vec<String>,
 }
 
 impl Ignores {
@@ -16,7 +16,7 @@ impl Ignores {
     pub fn add_static_array(&mut self, ignore: &[&str]) {
         for name in ignore.iter() {
             if (*name).ends_with("*") {
-                let substr = &(*name)[..(*name).len()-1];
+                let substr = &(*name)[..(*name).len() - 1];
                 self.prefixes.push(String::from(substr));
             }
             self.exact.insert(String::from(*name));

--- a/src/symbol_config.rs
+++ b/src/symbol_config.rs
@@ -5,27 +5,27 @@ use crate::CSAccess;
 
 #[derive(Clone, Copy)]
 pub struct SymbolConfig {
-    pub access: CSAccess
+    pub access: CSAccess,
 }
 
 impl Default for SymbolConfig {
     fn default() -> Self {
         SymbolConfig {
-            access: CSAccess::default()
+            access: CSAccess::default(),
         }
     }
 }
 
 pub struct SymbolConfigManager {
     pub ignores: Ignores,
-    pub config_map: HashMap<String, SymbolConfig>
+    pub config_map: HashMap<String, SymbolConfig>,
 }
 
 impl SymbolConfigManager {
     pub fn new() -> Self {
         SymbolConfigManager {
             ignores: Ignores::new(),
-            config_map: HashMap::new()
+            config_map: HashMap::new(),
         }
     }
 

--- a/tests/test_everything.rs
+++ b/tests/test_everything.rs
@@ -1,11 +1,8 @@
+use insta::assert_snapshot_matches;
 use std::fs;
 use std::path::PathBuf;
-use insta::assert_snapshot_matches;
 
-use csharpbindgen::{
-    Builder,
-    CSAccess
-};
+use csharpbindgen::{Builder, CSAccess};
 
 fn load_example(name: &'static str) -> String {
     let mut path = PathBuf::new();


### PR DESCRIPTION
As #3 alerted me to the fact that we don't currently use `rustfmt`, this PR adds a CircleCI task to ensure we're consistently formatted.  It also fixes all current formatting issues.
